### PR TITLE
Adds music player commands to discord bot and updates readme.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "dotenv": "^16.4.7",
         "openai": "^4.85.4",
         "prism-media": "^1.3.5",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "ytdl-core": "npm:@distube/ytdl-core@^4.16.4"
       },
       "devDependencies": {
         "@types/node": "^22.13.5",
@@ -1047,6 +1048,39 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-cookie-agent": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz",
+      "integrity": "sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^5.11.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-cookie-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -1248,6 +1282,25 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/m3u8stream": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+      "license": "MIT",
+      "dependencies": {
+        "miniget": "^4.2.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/m3u8stream/node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/magic-bytes.js": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
@@ -1306,6 +1359,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/miniget": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
+      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -1778,6 +1840,36 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "6.1.78",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.78.tgz",
+      "integrity": "sha512-fSgYrW0ITH0SR/CqKMXIruYIPpNu5aDgUp22UhYoSrnUQwc7SBqifEBFNce7AAcygUPBo6a/gbtcguWdmko4RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.78"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.78",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.78.tgz",
+      "integrity": "sha512-jS0svNsB99jR6AJBmfmEWuKIgz91Haya91Z43PATaeHJ24BkMoNRb/jlaD37VYjb0mYf6gRL/HOnvS1zEnYBiw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.1.tgz",
+      "integrity": "sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2016,6 +2108,65 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/ytdl-core": {
+      "name": "@distube/ytdl-core",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.4.tgz",
+      "integrity": "sha512-r0ZPMMB5rbUSQSez//dYDWjPSAEOm6eeV+9gyR+1vngGYFUi953Z/CoF4epTBS40X8dR32gyH3ERlh7NbnCaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^6.0.8",
+        "https-proxy-agent": "^7.0.6",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.3",
+        "sax": "^1.4.1",
+        "tough-cookie": "^5.1.0",
+        "undici": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
+      }
+    },
+    "node_modules/ytdl-core/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ytdl-core/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ytdl-core/node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
+    "node_modules/ytdl-core/node_modules/undici": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.3.0.tgz",
+      "integrity": "sha512-Qy96NND4Dou5jKoSJ2gm8ax8AJM/Ey9o9mz7KN1bb9GP+G0l20Zw8afxTnY2f4b7hmhn/z8aC2kfArVQlAhFBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dotenv": "^16.4.7",
     "openai": "^4.85.4",
     "prism-media": "^1.3.5",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "ytdl-core": "npm:@distube/ytdl-core@^4.16.4"
   },
   "devDependencies": {
     "@types/node": "^22.13.5",

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,8 @@ A feature-rich Discord bot that integrates ChatGPT for both conversational and c
 
 ## Usage
 
+### Chat Commands
+
 - **Chat with ChatGPT:**  
   Invoke `/chat` followed by your prompt.  
   _Example:_  
@@ -128,6 +130,23 @@ A feature-rich Discord bot that integrates ChatGPT for both conversational and c
 - **Help:**  
   Use `/help` to display all available commands with usage examples.
 
+### Music Commands
+
+- **Play:**
+  - Plays a song from YouTube. If there is no active music queue in the guild, the bot will join the user's voice channel and begin playback. Songs are added to a queue for continuous playback.  
+  _Example:_
+  `/play` url: https://www.youtube.com/watch?v=example`
+
+- **Skip:**
+  - Skips the currently playing song and advances to the next song in the queue.  
+  _Example:_
+  `skip`
+
+- **Stop:**
+  - Stops music playback, clears the music queue, and disconnects the bot from the voice channel.  
+  _Example:_
+  `stop`
+
 ## Development
 
 - **Modular Loading:**  
@@ -150,6 +169,11 @@ A feature-rich Discord bot that integrates ChatGPT for both conversational and c
 
 - **Additional Customization:**  
   Further refine interactions with additional customization options and NLP enhancements.
+
+- **Command integration with GPT**
+  It was my initial goal to build a generic integration between this GPT bot and other server bots through server bot registration and LLM _magic_. Sadly this isn't possible and violates discord TOS so instead I will have to include any useful bot commands for integration in this bot.
+
+  Goal #1 is a music player with voice and text prompting integration with GPT :D
 
 ## Contributing
 

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -1,0 +1,100 @@
+import { SlashCommandBuilder, CommandInteraction, CommandInteractionOptionResolver } from 'discord.js';
+import { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerStatus } from '@discordjs/voice';
+import { queues, Song, MusicQueue } from '../../music/musicQueue.js';
+import ytdl from 'ytdl-core';
+
+export class PlayCommand {
+  public data = new SlashCommandBuilder()
+    .setName('play')
+    .setDescription('Plays a song from YouTube')
+    .addStringOption(option =>
+      option.setName('url')
+        .setDescription('The YouTube URL')
+        .setRequired(true)
+    );
+
+  public async execute(interaction: CommandInteraction): Promise<void> {
+    if (!interaction.guildId) return;
+
+    // Check that the member is in a voice channel.
+    if (
+      !interaction.member ||
+      !('voice' in interaction.member) ||
+      !(interaction.member as any).voice.channel
+    ) {
+      await interaction.editReply("You need to be in a voice channel to play music!");
+      return;
+    }
+
+    const voiceChannel = (interaction.member as any).voice.channel;
+    const url = (interaction.options as CommandInteractionOptionResolver).getString('url', true);
+
+    // Validate the URL.
+    if (!ytdl.validateURL(url)) {
+      await interaction.editReply("Invalid YouTube URL.");
+      return;
+    }
+
+    // Retrieve song information.
+    const songInfo = await ytdl.getInfo(url);
+    const song: Song = {
+      title: songInfo.videoDetails.title,
+      url: songInfo.videoDetails.video_url,
+    };
+
+    const guildId = interaction.guildId;
+    let queue: MusicQueue | undefined = queues.get(guildId);
+
+    if (!queue) {
+      // Join the voice channel and create a new queue.
+      const connection = joinVoiceChannel({
+        channelId: voiceChannel.id,
+        guildId: interaction.guildId,
+        adapterCreator: interaction.guild!.voiceAdapterCreator,
+      });
+      const player = createAudioPlayer();
+      queue = {
+        connection,
+        player,
+        songs: [],
+      };
+      queues.set(guildId, queue);
+
+      // Subscribe the connection to the audio player.
+      queue.connection.subscribe(player);
+
+      // When the player becomes idle, move to the next song or clear the queue.
+      player.on(AudioPlayerStatus.Idle, () => {
+        queue!.songs.shift();
+        if (queue!.songs.length > 0) {
+          PlayCommand.playSong(guildId, queue!.songs[0]);
+        } else {
+          queue!.connection.destroy();
+          queues.delete(guildId);
+        }
+      });
+    }
+
+    // Add the song to the queue.
+    queue.songs.push(song);
+    if (queue.songs.length === 1) {
+      PlayCommand.playSong(guildId, song);
+    }
+
+    await interaction.editReply(`Added **${song.title}** to the queue.`);
+  }
+
+  private static playSong(guildId: string, song: Song): void {
+    const queue = queues.get(guildId);
+    if (!queue) return;
+    // Create a stream from the YouTube URL.
+    const stream = ytdl(song.url, {
+      filter: 'audioonly',
+      highWaterMark: 1 << 25,
+    });
+    const resource = createAudioResource(stream);
+    queue.player.play(resource);
+  }
+}
+
+export default new PlayCommand();

--- a/src/commands/music/skip.ts
+++ b/src/commands/music/skip.ts
@@ -1,0 +1,19 @@
+import { SlashCommandBuilder, CommandInteraction } from 'discord.js';
+import { queues } from '../../music/musicQueue.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('skip')
+    .setDescription('Skips the current song'),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.guildId) return;
+    const queue = queues.get(interaction.guildId);
+    if (!queue) {
+      await interaction.reply("There is no song playing.");
+      return;
+    }
+    // Stop the current song (the idle event will trigger the next song).
+    queue.player.stop();
+    await interaction.reply("Skipped the current song.");
+  },
+};

--- a/src/commands/music/stop.ts
+++ b/src/commands/music/stop.ts
@@ -1,0 +1,22 @@
+import { SlashCommandBuilder, CommandInteraction } from 'discord.js';
+import { queues } from '../../music/musicQueue.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('stop')
+    .setDescription('Stops the music and clears the queue'),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.guildId) return;
+    const queue = queues.get(interaction.guildId);
+    if (!queue) {
+      await interaction.editReply("There is no song playing.");
+      return;
+    }
+    // Clear the queue, stop playback, and disconnect.
+    queue.songs = [];
+    queue.player.stop();
+    queue.connection.destroy();
+    queues.delete(interaction.guildId);
+    await interaction.editReply("Stopped the music and cleared the queue.");
+  },
+};

--- a/src/core/DiscordBot.ts
+++ b/src/core/DiscordBot.ts
@@ -20,6 +20,9 @@ import ReadyEvent from '../events/ready.js';
 import InteractionCreateEvent from '../events/interactionCreate.js';
 import JoinVoiceChannelCommand from '../commands/joinVoiceChannel.js';
 import LeaveVoiceChannelCommand from '../commands/leaveVoiceChannel.js';
+import play from '../commands/music/play.js';
+import skip from '../commands/music/skip.js';
+import stop from '../commands/music/stop.js';
 
 export interface HistoryEntry {
   role: string;
@@ -114,7 +117,9 @@ export class DiscordBot {
       ContextChatCommand,
       ChatCommand,
       JoinVoiceChannelCommand(this.logger),
-      LeaveVoiceChannelCommand
+      play,
+      skip,
+      stop,
     ];
 
     for (const command of commands) {

--- a/src/music/musicQueue.ts
+++ b/src/music/musicQueue.ts
@@ -1,0 +1,14 @@
+import { VoiceConnection, createAudioPlayer } from '@discordjs/voice';
+
+export interface Song {
+  title: string;
+  url: string;
+}
+
+export interface MusicQueue {
+  connection: VoiceConnection;
+  player: ReturnType<typeof createAudioPlayer>;
+  songs: Song[];
+}
+
+export const queues = new Map<string, MusicQueue>();

--- a/types/ytdl-core.d.ts
+++ b/types/ytdl-core.d.ts
@@ -1,0 +1,6 @@
+declare module 'ytdl-core' {
+    // Use "any" for a quick fix. You can improve these typings later.
+    const ytdl: any;
+    export default ytdl;
+  }
+  


### PR DESCRIPTION
**Notes:**
This pull request introduces a new set of music commands to the Discord ChatGPT Bot, significantly enhancing the bot’s voice channel functionality. The update includes the following key changes:

• A new class-based /play command that retrieves YouTube video information using ytdl-core (aliased to the Distube fork) and streams audio into a voice channel via @discordjs/voice. The command now supports robust queue management so that songs can be queued for continuous playback.

• Integration of two additional music commands – /skip and /stop – allowing users to skip the current song or stop playback altogether, clearing the queue and disconnecting the bot from the voice channel.

• Documentation updates in the README file to include usage instructions and examples for the new music commands.

**Testing:**
Works on my machine don't ask for proof.